### PR TITLE
Migrate to Clang

### DIFF
--- a/libtex/src/main/jni/Application.mk
+++ b/libtex/src/main/jni/Application.mk
@@ -1,5 +1,4 @@
-NDK_TOOLCHAIN_VERSION := 4.9
-APP_STL := gnustl_static
+APP_STL := c++_static
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_ABI := armeabi-v7a arm64-v8a


### PR DESCRIPTION
Android moved to Clang several years ago. See https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md